### PR TITLE
Update prompts for linux compatibility 

### DIFF
--- a/modules/prompt/functions/prompt_paradox_setup
+++ b/modules/prompt/functions/prompt_paradox_setup
@@ -47,7 +47,7 @@ function prompt_paradox_end_segment {
 
 # AWS ACCOUNT NAME
 function aws_account_info {
-  if [[ "$AWS_ACCOUNT_NAME" && "$AWS_ACCOUNT_ROLE" ]]; then
+  if [[ ! -z "$AWS_ACCOUNT_NAME" && ! -z "$AWS_ACCOUNT_ROLE" ]]; then
     PARENT_ACCOUNT=${AWSUME_PROFILE:-"default"}
     prompt_paradox_start_segment 166 black
     if [[ "$PARENT_ACCOUNT" == "default" ]]; then
@@ -55,13 +55,13 @@ function aws_account_info {
     else
       prompt_paradox_start_segment 166 black "aws::${PARENT_ACCOUNT}.${AWS_ACCOUNT_NAME}:${AWS_ACCOUNT_ROLE}"
     fi
-  elif [[ "$AWSUME_PROFILE" && "$AWS_ACCESS_KEY_ID" && "$AWS_SECRET_ACCESS_KEY" ]]; then
+  elif [[ ! -z "$AWSUME_PROFILE" && ! -z "$AWS_ACCESS_KEY_ID" && ! -z "$AWS_SECRET_ACCESS_KEY" ]]; then
     prompt_paradox_start_segment 166 black "aws::${AWSUME_PROFILE}"
   fi
 }
 
 function ansible_vault_info {
-  if ([[ "$ANSIBLE_VAULT_PASSWORD_FILE" ]] || [[ "$ANSIBLE_VAULT_PASSWORD" ]]) && [[ "$ANSIBLE_VAULT_PASSWORD_LABEL" ]]; then
+  if ([[ ! -z "$ANSIBLE_VAULT_PASSWORD_FILE" ]] || [[ ! -z "$ANSIBLE_VAULT_PASSWORD" ]]) && [[ ! -z "$ANSIBLE_VAULT_PASSWORD_LABEL" ]]; then
     prompt_paradox_start_segment 242 253 "\uf023:${ANSIBLE_VAULT_PASSWORD_LABEL}"
   fi
 }

--- a/modules/prompt/functions/prompt_paradox_setup
+++ b/modules/prompt/functions/prompt_paradox_setup
@@ -47,7 +47,7 @@ function prompt_paradox_end_segment {
 
 # AWS ACCOUNT NAME
 function aws_account_info {
-  if [[ ! -z "$AWS_ACCOUNT_NAME" && ! -z "$AWS_ACCOUNT_ROLE" ]]; then
+  if [[ -n "$AWS_ACCOUNT_NAME" && -n "$AWS_ACCOUNT_ROLE" ]]; then
     PARENT_ACCOUNT=${AWSUME_PROFILE:-"default"}
     prompt_paradox_start_segment 166 black
     if [[ "$PARENT_ACCOUNT" == "default" ]]; then
@@ -55,13 +55,13 @@ function aws_account_info {
     else
       prompt_paradox_start_segment 166 black "aws::${PARENT_ACCOUNT}.${AWS_ACCOUNT_NAME}:${AWS_ACCOUNT_ROLE}"
     fi
-  elif [[ ! -z "$AWSUME_PROFILE" && ! -z "$AWS_ACCESS_KEY_ID" && ! -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+  elif [[ -n "$AWSUME_PROFILE" && -n "$AWS_ACCESS_KEY_ID" && -n "$AWS_SECRET_ACCESS_KEY" ]]; then
     prompt_paradox_start_segment 166 black "aws::${AWSUME_PROFILE}"
   fi
 }
 
 function ansible_vault_info {
-  if ([[ ! -z "$ANSIBLE_VAULT_PASSWORD_FILE" ]] || [[ ! -z "$ANSIBLE_VAULT_PASSWORD" ]]) && [[ ! -z "$ANSIBLE_VAULT_PASSWORD_LABEL" ]]; then
+  if ([[ -n "$ANSIBLE_VAULT_PASSWORD_FILE" ]] || [[ -n "$ANSIBLE_VAULT_PASSWORD" ]]) && [[ -n "$ANSIBLE_VAULT_PASSWORD_LABEL" ]]; then
     prompt_paradox_start_segment 242 253 "\uf023:${ANSIBLE_VAULT_PASSWORD_LABEL}"
   fi
 }


### PR DESCRIPTION
## Context
Fix errors caused during the creation of a vm-based development environment:
https://github.com/travelex/localenv-builder-vm/tree/DO-1803

## Issue
Default behaviour in vm, is for the following error to be displayed in the terminal after ssh'ing into the vm:
```
prompt_paradox_setup:50: parse error near `&&'
```

## Cause
~/.zshrc file, particularly the line below:
```
if [[ -s "${ZDOTDIR:-$HOME}/.zprezto/init.zsh" ]]; then
  source "${ZDOTDIR:-$HOME}/.zprezto/init.zsh"
fi
```

## Proposed solution
To follow the the pattern used in the rest of the file and using the `-n` switch